### PR TITLE
Add AWS provider and dev instance configuration

### DIFF
--- a/infrastructure/aws/dev/main.tf
+++ b/infrastructure/aws/dev/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "ap-south-1"
+}
+
+resource "aws_instance" "dev_instance" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+
+  tags = {
+    Environment = "dev"
+  }
+}


### PR DESCRIPTION
Added AWS dev infrastructure setup

This pull request adds the initial infrastructure setup for the AWS dev environment using Terraform.

- Created infrastructure/aws/dev/main.tf
- Defined basic EC2 instance configuration
- Structured environment-based folder setup